### PR TITLE
Fix cron update

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -46,11 +46,11 @@ jobs:
           command: run
           args: --release -- update --source node
 
-      - name: ⚙ Update QRs from GitHub releases
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --release -- update --source github
+      #- name: ⚙ Update QRs from GitHub releases
+      #  uses: actions-rs/cargo@v1
+      #  with:
+      #    command: run
+      #    args: --release -- update --source github
 
       - name: 📌 Commit changes if PR exists
         if: ${{ steps.checkout-pr.outputs.switched == 'true' }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,7 +3,7 @@ name: Check updates
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: '0 */6 * * *'
 
 env:
   BRANCH_PREFIX: sign-me


### PR DESCRIPTION
This PR comments out a check for new metadata in the github releases of the subtensor repo, and instead relies solely on the RPC node specified.   

This allows the update cron job to be re-activated.  

This PR also adjust the cron timing to `0 */6 * * *` which is every 6 hours.  