### PR TITLE
Fix Deploy Action Permissions

### DIFF
--- a/.github/workflows/deploy/action.yml
+++ b/.github/workflows/deploy/action.yml
@@ -3,6 +3,10 @@ inputs:
     description: 'Github token'
     required: true
 
+permissions:
+  pages: true
+  write: true
+
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
GH actions was getting 403 on pages deploy due to perms