### PR TITLE
Add read perm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy:
     permissions:
+      contents: read
       pages: write
     
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds the read perm as well. 

Should fix actions error: 
```
$ gh-pages -d build -u 'GitHub Action <action@github.com>'
remote: Permission to opentensor/metadata-portal.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/opentensor/metadata-portal.git/': The requested URL returned error: 403
```

See: https://stackoverflow.com/a/77412363